### PR TITLE
replaced `geo-offset` by `geo-buffer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 itertools = "0.14"
-tribool = "0.3"
 rayon = "1.10"
 slotmap = "1.0"
 float-cmp = "0.10"
@@ -24,6 +23,8 @@ thousands = "0.2.0"
 jiff = "0.2"
 criterion = "0.6"
 document-features = "0.2"
+geo-types = "0.7"
+geo-buffer = "0.2"
 
 [profile.release]
 opt-level = 3

--- a/jagua-rs/Cargo.toml
+++ b/jagua-rs/Cargo.toml
@@ -23,13 +23,10 @@ svg = {workspace = true}
 anyhow = {workspace = true}
 document-features = {workspace = true}
 rayon = { workspace = true }
-geo-offset = { version = "0.4.0", optional = true }
-geo-types = { version = "0.7.16", optional = true }
+geo-types = { workspace = true }
+geo-buffer = { workspace = true }
 
 [features]
-default = ["separation-distance"]
-## Enables support for defining a minimum separation distance between items and any hazard.
-separation-distance = ["dep:geo-offset", "dep:geo-types"]
 ## Enables support for the Strip Packing Problem
 spp = []
 ## Enables support for the Bin Packing Problem

--- a/jagua-rs/src/geometry/original_shape.rs
+++ b/jagua-rs/src/geometry/original_shape.rs
@@ -25,7 +25,9 @@ impl OriginalShape {
 
         if let Some(offset) = self.modify_config.offset {
             // Offset the shape
-            internal = offset_shape(&internal, self.modify_mode, offset)?;
+            if offset != 0.0 {
+                internal = offset_shape(&internal, self.modify_mode, offset)?;
+            }
         }
         if let Some(tolerance) = self.modify_config.simplify_tolerance {
             // Simplify the shape

--- a/jagua-rs/src/geometry/shape_modification.rs
+++ b/jagua-rs/src/geometry/shape_modification.rs
@@ -1,7 +1,5 @@
-#[cfg(feature = "separation-distance")]
-use geo_offset::Offset;
 use itertools::Itertools;
-use log::{debug, info};
+use log::{debug, info, warn};
 use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -11,7 +9,7 @@ use crate::geometry::primitives::Edge;
 use crate::geometry::primitives::Point;
 use crate::geometry::primitives::SPolygon;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 
 /// Whether to strictly inflate or deflate when making any modifications to shape.
 /// Depends on the [`position`](crate::collision_detection::hazards::HazardEntity::scope) of the [`HazardEntity`](crate::collision_detection::hazards::HazardEntity) that the shape represents.
@@ -328,7 +326,6 @@ impl CornerType {
 
 /// Offsets a [`SPolygon`] by a certain `distance` either inwards or outwards depending on the [`ShapeModifyMode`].
 /// Relies on the [`geo_offset`](https://crates.io/crates/geo_offset) crate.
-#[cfg(feature = "separation-distance")]
 pub fn offset_shape(sp: &SPolygon, mode: ShapeModifyMode, distance: f32) -> Result<SPolygon> {
     let offset = match mode {
         ShapeModifyMode::Deflate => -distance,
@@ -336,20 +333,33 @@ pub fn offset_shape(sp: &SPolygon, mode: ShapeModifyMode, distance: f32) -> Resu
     };
 
     // Convert the SPolygon to a geo_types::Polygon
-    let geo_poly =
-        geo_types::Polygon::new(sp.vertices.iter().map(|p| (p.0, p.1)).collect(), vec![]);
+    let geo_poly = geo_types::Polygon::new(
+        sp.vertices
+            .iter()
+            .map(|p| (p.0 as f64, p.1 as f64))
+            .collect(),
+        vec![],
+    );
 
-    // Create the offset geo_types::Polygon
-    let geo_poly_offset = geo_poly
-        .offset(offset)
-        .map_err(|e| anyhow::anyhow!("Error while offsetting polygon: {:?}", e))?
-        .0
-        .remove(0);
+    // Create the offset polygon
+    let geo_poly_offsets = geo_buffer::buffer_polygon_rounded(&geo_poly, offset as f64).0;
 
+    let geo_poly_offset = match geo_poly_offsets.len() {
+        0 => bail!("Offset resulted in an empty polygon"),
+        1 => &geo_poly_offsets[0],
+        _ => {
+            // If there are multiple polygons, we take the first one.
+            // This can happen if the offset creates multiple disconnected parts.
+            warn!("Offset resulted in multiple polygons, taking the first one.");
+            &geo_poly_offsets[0]
+        }
+    };
+
+    // Convert back to internal representation
     let mut points_offset = geo_poly_offset
         .exterior()
         .points()
-        .map(|p| Point(p.x(), p.y()))
+        .map(|p| Point(p.x() as f32, p.y() as f32))
         .collect_vec();
 
     //pop the last point if it is the same as the first
@@ -358,11 +368,4 @@ pub fn offset_shape(sp: &SPolygon, mode: ShapeModifyMode, distance: f32) -> Resu
     }
 
     SPolygon::new(points_offset)
-}
-
-#[cfg(not(feature = "separation-distance"))]
-pub fn offset_shape(_sp: &SPolygon, _mode: ShapeModifyMode, _distance: f32) -> Result<SPolygon> {
-    anyhow::bail!(
-        "cannot offset shape without geo_offset dependency, compile with --features separation to enable this"
-    )
 }

--- a/jagua-rs/src/geometry/shape_modification.rs
+++ b/jagua-rs/src/geometry/shape_modification.rs
@@ -9,6 +9,8 @@ use crate::geometry::primitives::Edge;
 use crate::geometry::primitives::Point;
 use crate::geometry::primitives::SPolygon;
 
+use crate::io::ext_repr::ExtSPolygon;
+use crate::io::import;
 use anyhow::{Result, bail};
 
 /// Whether to strictly inflate or deflate when making any modifications to shape.
@@ -355,17 +357,14 @@ pub fn offset_shape(sp: &SPolygon, mode: ShapeModifyMode, distance: f32) -> Resu
         }
     };
 
-    // Convert back to internal representation
-    let mut points_offset = geo_poly_offset
-        .exterior()
-        .points()
-        .map(|p| Point(p.x() as f32, p.y() as f32))
-        .collect_vec();
+    // Convert back to internal representation (by using the import function)
+    let ext_s_polygon = ExtSPolygon(
+        geo_poly_offset
+            .exterior()
+            .points()
+            .map(|p| (p.x() as f32, p.y() as f32))
+            .collect_vec(),
+    );
 
-    //pop the last point if it is the same as the first
-    if points_offset.first() == points_offset.last() {
-        points_offset.pop();
-    }
-
-    SPolygon::new(points_offset)
+    import::import_simple_polygon(&ext_s_polygon)
 }

--- a/jagua-rs/src/io/import.rs
+++ b/jagua-rs/src/io/import.rs
@@ -187,7 +187,7 @@ impl Importer {
     }
 }
 
-fn import_simple_polygon(sp: &ExtSPolygon) -> Result<SPolygon> {
+pub fn import_simple_polygon(sp: &ExtSPolygon) -> Result<SPolygon> {
     let mut points = sp.0.iter().map(|(x, y)| Point(*x, *y)).collect_vec();
     //Strip the last vertex if it is the same as the first one
     if points.len() > 1 && points[0] == points[points.len() - 1] {


### PR DESCRIPTION
- changed from `geo-offset` to `geo-buffer` for offsetting polygons.
- removed `separation-distance` feature flag, since `geo-buffer` is a pure Rust dependency and can always be included.

Relevant issues: #29, #22