### PR TITLE
Eliminated atomic ops during optimization

### DIFF
--- a/jagua-rs/src/collision_detection/hazards/hazard.rs
+++ b/jagua-rs/src/collision_detection/hazards/hazard.rs
@@ -4,7 +4,6 @@ use crate::geometry::geo_enums::GeoPosition;
 use crate::geometry::primitives::SPolygon;
 use slotmap::new_key_type;
 use std::borrow::Borrow;
-use std::sync::Arc;
 
 new_key_type! {
     /// Key to identify hazards inside the CDE.
@@ -18,13 +17,13 @@ pub struct Hazard {
     /// The entity inducing the hazard
     pub entity: HazardEntity,
     /// The shape of the hazard
-    pub shape: Arc<SPolygon>,
+    pub shape: SPolygon,
     /// Whether the hazard is dynamic, meaning it can change over time (e.g., moving items)
     pub dynamic: bool,
 }
 
 impl Hazard {
-    pub fn new(entity: HazardEntity, shape: Arc<SPolygon>, dynamic: bool) -> Self {
+    pub fn new(entity: HazardEntity, shape: SPolygon, dynamic: bool) -> Self {
         Self {
             entity,
             shape,

--- a/jagua-rs/src/collision_detection/quadtree/qt_hazard.rs
+++ b/jagua-rs/src/collision_detection/quadtree/qt_hazard.rs
@@ -59,7 +59,7 @@ impl QTHazard {
             QTHazPresence::Partial(partial_haz) => {
                 //If the hazard is partially present, we need to check which type of presence each quadrant has
 
-                let haz_shape = haz_map[self.hkey].shape.as_ref();
+                let haz_shape = &haz_map[self.hkey].shape;
 
                 //Check if one of the quadrants entirely contains the hazard
                 let enclosed_hazard_quadrant = quadrants

--- a/jagua-rs/src/entities/container.rs
+++ b/jagua-rs/src/entities/container.rs
@@ -54,7 +54,11 @@ impl Container {
         };
 
         let base_cde = {
-            let mut hazards = vec![Hazard::new(HazardEntity::Exterior, outer.clone(), false)];
+            let mut hazards = vec![Hazard::new(
+                HazardEntity::Exterior,
+                outer.as_ref().clone(),
+                false,
+            )];
             let qz_hazards = quality_zones
                 .iter()
                 .flatten()
@@ -123,7 +127,7 @@ impl InferiorQualityZone {
                     idx,
                 },
             };
-            Hazard::new(entity, shape.clone(), false)
+            Hazard::new(entity, shape.as_ref().clone(), false)
         })
     }
 

--- a/jagua-rs/src/entities/placed_item.rs
+++ b/jagua-rs/src/entities/placed_item.rs
@@ -3,7 +3,6 @@ use crate::geometry::DTransformation;
 use crate::geometry::geo_traits::Transformable;
 use crate::geometry::primitives::SPolygon;
 use slotmap::new_key_type;
-use std::sync::Arc;
 
 #[cfg(doc)]
 use crate::entities::Layout;
@@ -21,13 +20,13 @@ pub struct PlacedItem {
     /// The transformation that was applied to the `Item` before it was placed
     pub d_transf: DTransformation,
     /// The shape of the `Item` after it has been transformed and placed in a `Layout`
-    pub shape: Arc<SPolygon>,
+    pub shape: SPolygon,
 }
 
 impl PlacedItem {
     pub fn new(item: &Item, d_transf: DTransformation) -> Self {
         let transf = d_transf.compose();
-        let shape = Arc::new(item.shape_cd.transform_clone(&transf));
+        let shape = item.shape_cd.transform_clone(&transf);
 
         PlacedItem {
             item_id: item.id,

--- a/jagua-rs/src/io/svg/layout_to_svg.rs
+++ b/jagua-rs/src/io/svg/layout_to_svg.rs
@@ -334,7 +334,7 @@ pub fn layout_to_svg(
                         BasicHazardCollector::with_capacity(layout.cde().hazards_map.len());
                     layout
                         .cde()
-                        .collect_poly_collisions(pi.shape.as_ref(), &mut collector);
+                        .collect_poly_collisions(&pi.shape, &mut collector);
                     collector.retain(|_, entity| {
                         // filter out the item itself
                         if let HazardEntity::PlacedItem {


### PR DESCRIPTION
Only place where `Arc<T>` is still used is in static structs