### PR TITLE
Refactor hazard and placed item structures to use Arc for shape

### DIFF
--- a/jagua-rs/src/collision_detection/hazards/hazard.rs
+++ b/jagua-rs/src/collision_detection/hazards/hazard.rs
@@ -4,6 +4,7 @@ use crate::geometry::geo_enums::GeoPosition;
 use crate::geometry::primitives::SPolygon;
 use slotmap::new_key_type;
 use std::borrow::Borrow;
+use std::sync::Arc;
 
 new_key_type! {
     /// Key to identify hazards inside the CDE.
@@ -17,13 +18,13 @@ pub struct Hazard {
     /// The entity inducing the hazard
     pub entity: HazardEntity,
     /// The shape of the hazard
-    pub shape: SPolygon,
+    pub shape: Arc<SPolygon>,
     /// Whether the hazard is dynamic, meaning it can change over time (e.g., moving items)
     pub dynamic: bool,
 }
 
 impl Hazard {
-    pub fn new(entity: HazardEntity, shape: SPolygon, dynamic: bool) -> Self {
+    pub fn new(entity: HazardEntity, shape: Arc<SPolygon>, dynamic: bool) -> Self {
         Self {
             entity,
             shape,

--- a/jagua-rs/src/entities/container.rs
+++ b/jagua-rs/src/entities/container.rs
@@ -55,11 +55,7 @@ impl Container {
         };
 
         let base_cde = {
-            let mut hazards = vec![Hazard::new(
-                HazardEntity::Exterior,
-                outer.clone(),
-                false,
-            )];
+            let mut hazards = vec![Hazard::new(HazardEntity::Exterior, outer.clone(), false)];
             let qz_hazards = quality_zones
                 .iter()
                 .flatten()

--- a/jagua-rs/src/entities/container.rs
+++ b/jagua-rs/src/entities/container.rs
@@ -57,7 +57,7 @@ impl Container {
         let base_cde = {
             let mut hazards = vec![Hazard::new(
                 HazardEntity::Exterior,
-                outer.as_ref().clone(),
+                outer.clone(),
                 false,
             )];
             let qz_hazards = quality_zones
@@ -128,7 +128,7 @@ impl InferiorQualityZone {
                     idx,
                 },
             };
-            Hazard::new(entity, shape.as_ref().clone(), false)
+            Hazard::new(entity, shape.clone(), false)
         })
     }
 

--- a/jagua-rs/src/entities/placed_item.rs
+++ b/jagua-rs/src/entities/placed_item.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use crate::entities::Item;
 use crate::geometry::DTransformation;
 use crate::geometry::geo_traits::Transformable;
@@ -20,7 +21,7 @@ pub struct PlacedItem {
     /// The transformation that was applied to the `Item` before it was placed
     pub d_transf: DTransformation,
     /// The shape of the `Item` after it has been transformed and placed in a `Layout`
-    pub shape: SPolygon,
+    pub shape: Arc<SPolygon>,
 }
 
 impl PlacedItem {
@@ -31,7 +32,7 @@ impl PlacedItem {
         PlacedItem {
             item_id: item.id,
             d_transf,
-            shape,
+            shape: Arc::new(shape),
         }
     }
 }

--- a/jagua-rs/src/entities/placed_item.rs
+++ b/jagua-rs/src/entities/placed_item.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
 use crate::entities::Item;
 use crate::geometry::DTransformation;
 use crate::geometry::geo_traits::Transformable;
 use crate::geometry::primitives::SPolygon;
 use slotmap::new_key_type;
+use std::sync::Arc;
 
 #[cfg(doc)]
 use crate::entities::Layout;


### PR DESCRIPTION
Previously, SPolygons were cloned when an item was placed into the layout and when the hazard was registered in the cde. 

This changes suggests using an Arc-pointer to the SPolygon instead of a deep-copy. 

For small shapes, this change doesn't affect the performance a lot, but when SPolygons grow, the proposed method should be faster.