### PR TITLE
Use stable Rust in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: fmt
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- switch the main CI workflow from nightly Rust to stable Rust
- leave the rest of the CI steps unchanged

## Why

The project previously used nightly in CI, but it may no longer be required. This draft PR lets the full pipeline verify whether stable is sufficient.

## Validation

- git diff --check