### PR TITLE
Make quadtree debug assertion robust to f32 rounding

### DIFF
--- a/jagua-rs/Cargo.toml
+++ b/jagua-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jagua-rs"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "MPL-2.0"
 repository = "https://github.com/JeroenGar/jagua-rs"

--- a/jagua-rs/src/collision_detection/quadtree/assertions.rs
+++ b/jagua-rs/src/collision_detection/quadtree/assertions.rs
@@ -1,0 +1,48 @@
+use crate::geometry::primitives::{Edge, Rect};
+
+pub(super) fn edge_quadrant_classification_is_conservative(
+    edge: &Edge,
+    quadrants: [&Rect; 4],
+    classified: [bool; 4],
+) -> bool {
+    edge_collisions_with_rects_f64(edge, quadrants)
+        .into_iter()
+        .zip(classified)
+        .all(|(collides, classified)| !collides || classified)
+}
+
+pub(super) fn edge_collisions_with_rects_f64(edge: &Edge, rects: [&Rect; 4]) -> [bool; 4] {
+    rects.map(|rect| edge_collides_with_rect_f64(edge, rect))
+}
+
+/// Recomputes the segment-rectangle intersection in `f64` so assertions do not inherit
+/// conservative rounding from the production `f32` predicate.
+#[allow(clippy::similar_names)]
+fn edge_collides_with_rect_f64(edge: &Edge, rect: &Rect) -> bool {
+    let (start_x, start_y) = (f64::from(edge.start.0), f64::from(edge.start.1));
+    let (end_x, end_y) = (f64::from(edge.end.0), f64::from(edge.end.1));
+    let (x_min, y_min) = (f64::from(rect.x_min), f64::from(rect.y_min));
+    let (x_max, y_max) = (f64::from(rect.x_max), f64::from(rect.y_max));
+
+    let x_no_overlap = start_x.min(end_x).max(x_min) > start_x.max(end_x).min(x_max);
+    let y_no_overlap = start_y.min(end_y).max(y_min) > start_y.max(end_y).min(y_max);
+    if x_no_overlap || y_no_overlap {
+        return false;
+    }
+
+    let point_in_rect = |x, y| x >= x_min && x <= x_max && y >= y_min && y <= y_max;
+    if point_in_rect(start_x, start_y) || point_in_rect(end_x, end_y) {
+        return true;
+    }
+
+    let edge_dx = end_x - start_x;
+    let edge_dy = end_y - start_y;
+    let sides = [
+        (x_max - start_x) * edge_dy - (y_max - start_y) * edge_dx,
+        (x_min - start_x) * edge_dy - (y_max - start_y) * edge_dx,
+        (x_min - start_x) * edge_dy - (y_min - start_y) * edge_dx,
+        (x_max - start_x) * edge_dy - (y_min - start_y) * edge_dx,
+    ];
+
+    !sides.iter().all(|side| *side > 0.0) && !sides.iter().all(|side| *side < 0.0)
+}

--- a/jagua-rs/src/collision_detection/quadtree/mod.rs
+++ b/jagua-rs/src/collision_detection/quadtree/mod.rs
@@ -1,8 +1,13 @@
+#[cfg(any(debug_assertions, test))]
+mod assertions;
 mod qt_hazard;
 mod qt_hazard_vec;
 mod qt_node;
 mod qt_partial_hazard;
 mod qt_traits;
+
+#[cfg(test)]
+mod tests;
 
 #[doc(inline)]
 pub use qt_hazard::QTHazPresence;

--- a/jagua-rs/src/collision_detection/quadtree/qt_traits.rs
+++ b/jagua-rs/src/collision_detection/quadtree/qt_traits.rs
@@ -3,6 +3,9 @@ use crate::geometry::primitives::Rect;
 use crate::geometry::primitives::{Circle, Edge, Point};
 use std::cmp::Ordering;
 
+#[cfg(debug_assertions)]
+use super::assertions;
+
 /// Common trait for all geometric primitives that can be directly queried in the quadtree
 /// for collisions with the edges of the registered hazards. These include: [Rect], [Edge] and [Circle].
 pub trait QTQueryable: CollidesWith<Edge> + CollidesWith<Rect> {
@@ -114,25 +117,15 @@ impl QTQueryable for Edge {
             [&mut c_q0, &mut c_q1],
         );
 
-        let [c_q0, c_q1, c_q2, c_q3] = [c_q0, c_q1, c_q2, c_q3].map(|c| c.unwrap_or(false));
+        let classified = [c_q0, c_q1, c_q2, c_q3].map(|collision| collision.unwrap_or(false));
+        #[cfg(debug_assertions)]
         debug_assert!(
-            {
-                // make sure all quadrants which are colliding according to the individual collision check are at least
-                // also caught by the quadrant collision check
-                qs.map(|q| self.collides_with(q))
-                    .iter()
-                    .zip([c_q0, c_q1, c_q2, c_q3].iter())
-                    .all(|(&i_c, &q_c)| !i_c || q_c)
-            },
-            "{:?}, {:?}, {:?}, {:?}, {:?}",
-            self,
-            r,
-            qs,
-            [c_q0, c_q1, c_q2, c_q3],
-            qs.map(|q| self.collides_with(q))
+            assertions::edge_quadrant_classification_is_conservative(self, qs, classified),
+            "edge: {self:?}, node: {r:?}, quadrants: {qs:?}, classified: {classified:?}, f64 oracle: {:?}",
+            assertions::edge_collisions_with_rects_f64(self, qs)
         );
 
-        [c_q0, c_q1, c_q2, c_q3]
+        classified
     }
 }
 

--- a/jagua-rs/src/collision_detection/quadtree/tests.rs
+++ b/jagua-rs/src/collision_detection/quadtree/tests.rs
@@ -1,0 +1,36 @@
+use super::assertions;
+use super::qt_traits::QTQueryable;
+use crate::geometry::geo_traits::CollidesWith;
+use crate::geometry::primitives::{Edge, Point, Rect};
+
+#[test]
+fn edge_quadrants_allow_f32_false_positive_at_bisector() {
+    let rect = Rect::try_new(0.0, 6.1875, 100.0, 106.1875).unwrap();
+    let quadrants = rect.quadrants();
+    let edge = Edge {
+        start: Point(-29.439_144, -32.354_836),
+        end: Point(51.902_332, 212.291_02),
+    };
+    let bisector_y = rect.centroid().1;
+    let crossing_fraction =
+        -f64::from(edge.start.0) / (f64::from(edge.end.0) - f64::from(edge.start.0));
+    let crossing_y = f64::from(edge.start.1)
+        + crossing_fraction * (f64::from(edge.end.1) - f64::from(edge.start.1));
+    let bisector_ulp = f32::from_bits(bisector_y.to_bits() + 1) - bisector_y;
+
+    assert!(crossing_y > f64::from(bisector_y));
+    assert!(crossing_y - f64::from(bisector_y) < f64::from(bisector_ulp));
+
+    assert_eq!(
+        quadrants.map(|quadrant| edge.collides_with(&quadrant)),
+        [false, true, true, false]
+    );
+    assert_eq!(
+        assertions::edge_collisions_with_rects_f64(&edge, quadrants.each_ref()),
+        [false, true, false, false]
+    );
+    assert_eq!(
+        edge.collides_with_quadrants(&rect, quadrants.each_ref()),
+        [false, true, false, false]
+    );
+}


### PR DESCRIPTION
## Summary

- use an independent f64 segment-rectangle collision check as the debug oracle
- add a regression test for the sub-ULP bisector case from #86
- bump jagua-rs to 0.8.1

This addresses the qt_traits false alarm discussed in #86. It does not change the separate qt_hazard assertion, which still needs the reporter's exact reproducer.

## Checks

- cargo fmt --all -- --check
- cargo test --workspace --all-features
- cargo package -p jagua-rs --allow-dirty